### PR TITLE
Fix passing go-version to setup-go action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,8 +13,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
       - name: golangci-lint


### PR DESCRIPTION
I believe we want to set `go-version` to the `setup-go` action, and not to the checkout action. I also put the setup-go as the action after the checkout, this is more conventional I believe and we can see it on the example at setup-go's readme: https://github.com/actions/setup-go#readme